### PR TITLE
サインイン機能を実装

### DIFF
--- a/app/assets/stylesheets/v1/auth/registrations.scss
+++ b/app/assets/stylesheets/v1/auth/registrations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the v1/auth/registrations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,0 +1,4 @@
+class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  skip_before_action :verify_authenticity_token
+end
+

--- a/app/helpers/v1/auth/registrations_helper.rb
+++ b/app/helpers/v1/auth/registrations_helper.rb
@@ -1,0 +1,2 @@
+module V1::Auth::RegistrationsHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,7 @@ Rails.application.routes.draw do
   get 'articles/destroy'
   mount_devise_token_auth_for 'User', at: 'auth'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :v1 do
+    mount_devise_token_auth_for "User", at: "auth"
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_08_090103) do
+ActiveRecord::Schema.define(version: 2022_01_08_075442) do
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
 
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "text"

--- a/test/controllers/v1/auth/registrations_controller_test.rb
+++ b/test/controllers/v1/auth/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class V1::Auth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 行った対応
* サインイン機能を実装
* ログイン機能の実装
* ログアウト機能の実装

## 行っていないこと
chromeの拡張機能「Advanced rest client」でPOSTしたとき、
CSRF関連のエラーが帰ってくる。←これの解消

# エンドポイント
## サインイン
POST http://127.0.0.1:3000/v1/auth

## ログイン
POST http://127.0.0.1:3000/v1/auth/sign_in

## ログアウト
DELETE http://127.0.0.1:3000/v1/auth/sign_out


# リクエストボディー
## サインインとログイン
{
"email" : "test@example.com"
"passwordl" : "password"
}

## ログアウト
{
"uidl" : "test@example.com"
"access-token" : "xxxx"
"client" : "xxxx"
}

## ここ見れば何のパラメータが必要かわかる
https://devise-token-auth.gitbook.io/devise-token-auth/usage

